### PR TITLE
F add optional error support

### DIFF
--- a/include/anywho.hpp
+++ b/include/anywho.hpp
@@ -1,9 +1,11 @@
 #pragma once
-
+#if __cplusplus > 202002L
 #include "concepts.hpp"
+#include "error_factories.hpp"
+#endif
 #include "context.hpp"
 #include "direct_return.hpp"
-#include "error_factories.hpp"
 #include "errors.hpp"
 #include "fixed_string.hpp"
+#include "format.hpp"
 #include "with_context.hpp"

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -1,9 +1,6 @@
 #pragma once
-
-#include <expected>
-#include <format>
-
 #include "fixed_string.hpp"
+#include "format.hpp"
 
 namespace anywho {
 /**
@@ -20,7 +17,7 @@ struct Context final
 
   std::string format() const
   {
-    return std::format("{}:{} -> {}", static_cast<std::string>(file), line, static_cast<std::string>(message));
+    return format_ns::format("{}:{} -> {}", static_cast<std::string>(file), line, static_cast<std::string>(message));
   }
 };
 

--- a/include/direct_return.hpp
+++ b/include/direct_return.hpp
@@ -3,18 +3,41 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-statement-expression"
 #endif
+#include "has_error.hpp"
+
+#if __cplusplus > 202002L
 /**
  * @brief Macro allowing to return directly the unexpected value or continue with the truth value (without std::expected
  * wrapped around it) the extension "gnu statement expression" is currently the only way to solve this but supported by
  * gcc, clang and msvc
  *
  */
-#define ANYWHO(expr)                                                     \
-  __extension__({                                                        \
-    auto result = expr;                                                  \
-    if (!result.has_value()) { return std::unexpected(result.error()); } \
-    result.value();                                                      \
+#define ANYWHO(expr)                                                           \
+  __extension__({                                                              \
+    auto result = expr;                                                        \
+    if (anywho::has_error(result)) { return std::unexpected(result.error()); } \
+    result.value();                                                            \
   })
+
+#define ANYWHO_OPT(expr)                                                          \
+  __extension__({                                                                 \
+    auto result = expr;                                                           \
+    if (anywho::has_error(result)) { return std::make_optional(result.error()); } \
+    result.value();                                                               \
+  })
+
+#endif// c++23 guard
+/**
+ * @brief Same as ANYWHO but for std::optional<Error>. For projects that are bound to version before cpp23.
+ *        Attention: optEror.has_value() means it has an error which is unintuitive.
+ *
+ */
+#define ANYWHO_LEGACY(expr)                                                       \
+  __extension__({                                                                 \
+    auto result = expr;                                                           \
+    if (anywho::has_error(result)) { return std::make_optional(result.value()); } \
+  })
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/include/direct_return.hpp
+++ b/include/direct_return.hpp
@@ -29,7 +29,6 @@
 #endif// c++23 guard
 /**
  * @brief Same as ANYWHO but for std::optional<Error>. For projects that are bound to version before cpp23.
- *        Attention: optEror.has_value() means it has an error which is unintuitive.
  *
  */
 #define ANYWHO_LEGACY(expr)                                                       \

--- a/include/error_factories.hpp
+++ b/include/error_factories.hpp
@@ -46,6 +46,40 @@ inline std::expected<T, E> make_error(std::function<std::tuple<bool, T>(void)> c
 }
 
 /**
+ * @brief Factory function for functions std::optional<Error>
+ *
+ * @tparam T Type of the expected value
+ * @tparam E Error type
+ * @param error optional error, having error or not
+ * @param truth_value Expected value
+ * @return std::expected<T, E>
+ */
+template<typename T, concepts::Error E> inline std::expected<T, E> make_error(std::optional<E> &&error, T truth_value)
+{
+  if (!has_error(error)) {
+    return std::expected<T, E>{ truth_value };
+  } else {
+    return std::unexpected(error.value());
+  }
+}
+
+/**
+ * @brief Factory function for functions std::optional<Error>
+ *
+ * @tparam T Type of the expected value
+ * @tparam E Error type
+ * @param callable Callable in which the function that shall be evaluated is wrapped
+ * @return std::expected<T, E>
+ */
+template<typename T, concepts::Error E>
+inline std::expected<T, E> make_error(std::function<std::tuple<std::optional<E>, T>(void)> callable)
+{
+  auto [error, truth_value] = callable();
+
+  return make_error(std::move(error), truth_value);
+}
+
+/**
  * @brief Factory function for functions using std::error_code
  *
  * @tparam T Type of the expected value

--- a/include/error_from_exception.hpp
+++ b/include/error_from_exception.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "errors.hpp"
+#include "format.hpp"
 #include <exception>
-#include <format>
 #include <memory>
 #include <string>
 
@@ -20,7 +20,7 @@ public:
   ErrorFromException(const std::shared_ptr<std::exception> &exc) : exc_{ exc } {}
   [[nodiscard]] constexpr std::string message() const override
   {
-    return std::format("error happened with exception '{}'", exc_->what());
+    return format_ns::format("error happened with exception '{}'", exc_->what());
   }
 
   [[nodiscard]] const std::shared_ptr<std::exception> &get_exception_ptr() const { return exc_; }
@@ -30,6 +30,7 @@ private:
   std::shared_ptr<std::exception> exc_;
 };
 
+#if __cplusplus > 202002L
 /**
  * @brief Factory for ErrorFromException. This can be used as a bridge from exception bsed error handling.
  * Example:
@@ -80,6 +81,7 @@ inline std::expected<T, E> make_any_error_from_throwable(std::function<T(void)> 
     return with_context(std::move(exp), { .message = exc.what(), .line = __LINE__, .file = std::string(__FILE__) });
   }
 }
+#endif
 
 
 }// namespace anywho

--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -57,7 +57,7 @@ public:
 
   void consume_context(anywho::Context &&context)
   {
-    message_ = std::format("{}::{}", static_cast<std::string>(message_), context.format());
+    message_ = format_ns::format("{}::{}", static_cast<std::string>(message_), context.format());
   }
 
   [[nodiscard]] virtual constexpr std::string message() const { return "fixed size error happened"; }
@@ -78,7 +78,7 @@ public:
   ErrorFromCode(std::error_code &&code) : code_{ std::move(code) } {}
   [[nodiscard]] constexpr std::string message() const override
   {
-    return std::format("error happened with code {} and message {}", code_.value(), code_.message());
+    return format_ns::format("error happened with code {} and message {}", code_.value(), code_.message());
   }
 
   [[nodiscard]] const std::error_code &get_code() const { return code_; }

--- a/include/format.hpp
+++ b/include/format.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#if __cplusplus > 202002L
+// For C++20 and later, use std::format
+#include <format>
+namespace anywho {
+namespace format_ns = std;
+}// namespace anywho
+#else
+// For versions before C++20, use fmt::format
+#include <fmt/core.h>
+namespace anywho {
+namespace format_ns = fmt;
+}// namespace anywho
+#endif

--- a/include/has_error.hpp
+++ b/include/has_error.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <expected>
+#include <optional>
+namespace anywho {
+
+// We might want to use the concepts here but than we could not represent error as strings or other types...
+template<typename E> inline bool has_error(const std::optional<E> &x) { return x.has_value(); }
+
+#if __cplusplus > 202002L
+template<typename T, typename E> inline bool has_error(const std::expected<T, E> &x) { return !x.has_value(); }
+#endif
+}// namespace anywho

--- a/include/with_context.hpp
+++ b/include/with_context.hpp
@@ -2,6 +2,7 @@
 
 #include "concepts.hpp"
 #include "context.hpp"
+#include "has_error.hpp"
 #include <expected>
 
 namespace anywho {
@@ -14,6 +15,7 @@ namespace anywho {
  * @param context Context to add
  * @return std::expected<V, E>
  */
+#if __cplusplus > 202002L
 template<typename V, concepts::Error E>
 inline std::expected<V, E> with_context(std::expected<V, E> &&exp, Context &&context)
 {
@@ -21,5 +23,26 @@ inline std::expected<V, E> with_context(std::expected<V, E> &&exp, Context &&con
     x.consume_context(std::move(cont));
     return x;
   });
+}
+#endif
+
+/**
+ * @brief Helper to add context to std::expected holding an error.
+ *
+ * @tparam V Type of the expected value
+ * @tparam E Type of the error
+ * @param exp Object to which context will be added
+ * @param context Context to add
+ * @return std::expected<V, E>
+ */
+#if __cplusplus > 202002L
+template<concepts::Error E>
+#else
+template<typename E>
+#endif
+inline std::optional<E> with_context(std::optional<E> &&exp, Context &&context)
+{
+  if (has_error(exp)) { exp = std::make_optional(exp.value().consume_context(std::move(context))); }
+  return exp;
 }
 }// namespace anywho

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -11,13 +11,13 @@ namespace direct_return_expected {
 
   std::expected<int, std::string> myfuncValid() { return 3; }
 
-  std::expected<int, std::string> myfunc0()
+  std::expected<int, std::string> myfuncUnexpectedRaised()
   {
     const int val = ANYWHO(myfuncUnexpected());
     return 3 * val;
   }
 
-  std::expected<int, std::string> myfunc1()
+  std::expected<int, std::string> myfuncValidRaised()
   {
     const int val = ANYWHO(myfuncValid());
     return 3 * val;
@@ -39,19 +39,7 @@ namespace direct_return_optional {
 
   std::expected<int, DummyError> myfuncValid() { return 3; }
 
-  // std::optional<DummyError> myfuncOptError(int &output)
-  // {
-  //   output = 3;
-  //   return std::make_optional(DummyError{});
-  // }
-
-  // std::optional<DummyError> myfuncOptValid(int &output)
-  // {
-  //   output = 3;
-  //   return std::nullopt;
-  // }
-
-  std::optional<DummyError> myfunc0(int &val)
+  std::optional<DummyError> myfuncUnexpectedRaised(int &val)
   {
     int val_cur = ANYWHO_OPT(myfuncUnexpected());
     val = 3 * val_cur;
@@ -59,10 +47,26 @@ namespace direct_return_optional {
     return std::nullopt;
   }
 
-  std::optional<DummyError> myfunc1(int &val)
+  std::optional<DummyError> myfuncValidRaised(int &val)
   {
     int val_cur = ANYWHO_OPT(myfuncValid());
     val = 3 * val_cur;
+
+    return std::nullopt;
+  }
+
+  std::optional<DummyError> myfuncUnexpectedRaised2(int &val)
+  {
+    ANYWHO_LEGACY(myfuncUnexpectedRaised(val));
+    val = 3 * val;
+
+    return std::nullopt;
+  }
+
+  std::optional<DummyError> myfuncValidRaised2(int &val)
+  {
+    ANYWHO_LEGACY(myfuncValidRaised(val));
+    val = 3 * val;
 
     return std::nullopt;
   }
@@ -115,13 +119,13 @@ std::optional<DummyError> positiveOnlySquareWithOptional(int num, int &output)
 
 TEST_CASE("error get returned with anywho", "[direct_return]")
 {
-  auto result = direct_return_expected::myfunc0();
+  auto result = direct_return_expected::myfuncUnexpectedRaised();
   REQUIRE(!result.has_value());
   REQUIRE(result.error() == "my_msg");
 }
 TEST_CASE("value get returned with anywho", "[direct_return]")
 {
-  auto result = direct_return_expected::myfunc1();
+  auto result = direct_return_expected::myfuncValidRaised();
   REQUIRE(result.has_value());
   REQUIRE(result.value() == 9);
 }
@@ -129,15 +133,29 @@ TEST_CASE("value get returned with anywho", "[direct_return]")
 TEST_CASE("error get returned with anywho_opt", "[direct_return]")
 {
   int val = 0;
-  std::optional<DummyError> result = direct_return_optional::myfunc0(val);
+  std::optional<DummyError> result = direct_return_optional::myfuncUnexpectedRaised(val);
   REQUIRE(anywho::has_error(result));
 }
 TEST_CASE("value get returned with anywho_opt", "[direct_return]")
 {
   int val = 0;
-  std::optional<DummyError> result = direct_return_optional::myfunc1(val);
+  std::optional<DummyError> result = direct_return_optional::myfuncValidRaised(val);
   REQUIRE(!anywho::has_error(result));
   REQUIRE(val == 9);
+}
+
+TEST_CASE("error get returned with anywho_legacy", "[direct_return]")
+{
+  int val = 0;
+  std::optional<DummyError> result = direct_return_optional::myfuncUnexpectedRaised2(val);
+  REQUIRE(anywho::has_error(result));
+}
+TEST_CASE("value get returned with anywho_legacy", "[direct_return]")
+{
+  int val = 0;
+  std::optional<DummyError> result = direct_return_optional::myfuncValidRaised2(val);
+  REQUIRE(!anywho::has_error(result));
+  REQUIRE(val == 27);
 }
 
 TEST_CASE("fixed string", "[FixedString]")


### PR DESCRIPTION
Add support for optional<Error> to facilitate working together with c++17 code that uses this as error handling mechanism.
Add anywho macros for optional<Error>, tests and  make Error c++17 compatible. So that they can bubble up through parts of the code that can use c++23 and c++17 